### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ $ cd /User/<YourUser>/repos/
 ```bash
 $ git clone https://github.com/hrwakeford/ExoTiC-ISM.git
 ```
+or use SSH if that is your preferred way of cloning repositories:
+```bash
+$ git clone git@github.com:hrwakeford/ExoTiC-ISM.git
+```
 
 - Navigate into the cloned repository:  
 ```bash

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.tx
 
 ### Acknowledgments
 
+* Tom J. Wilson for statistical testing of the code
 * Matthew Hill for a functional translation from IDL to Python
 * Iva Laginja for finding `Sherpa`, making the clunky `mpfit` dispensable
 * The [`Sherpa` team](https://github.com/sherpa/sherpa), providing a fantastic package and answering fast to GitHub issues


### PR DESCRIPTION
Quickfix for readme that adds the option to clone via SSH explicitly to the readme, as well as Tom to the README acknowledgements.