### PR TITLE
Fix typo in grating choice for limb darkening

### DIFF
--- a/exoticism/limb_darkening.py
+++ b/exoticism/limb_darkening.py
@@ -257,7 +257,7 @@ def limb_dark_fit(grating, wsdata, M_H, Teff, logg, dirsen, ld_model='1D'):
         wdel = 1
 
     if grating == 'G102':  # http://www.stsci.edu/hst/acs/analysis/reference_files/synphot_tables.html
-        sav = readsav(os.path.join(dirsen, 'G141.WFC3.sensitivity.sav'))  # wssens, sensitivity
+        sav = readsav(os.path.join(dirsen, 'G102.WFC3.sensitivity.sav'))  # wssens, sensitivity
         wssens = sav['wssens']
         sensitivity = sav['sensitivity']
         wdel = 1


### PR DESCRIPTION
As reported by @guangweifu in #107 I fixed the typo in the choice of grating in the `limb_darkening.py`.