### PR TITLE
Add regression test for W17 / fit_time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.iml
+.DS_Store
 config_local.ini
 outputs/
 .ipynb_checkpoints/

--- a/exoticism/marginalisation.py
+++ b/exoticism/marginalisation.py
@@ -51,7 +51,7 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_sel
     :param err: array of error values corresponding to the flux values in y
     :param sh: array corresponding to the shift in wavelength position on the detector throughout the visit. (same length as x, y and err); can be None
     :param wavelength: array of wavelengths covered to compute y
-    :param ld_model: string, '3D' or '2D', defines which limb darkening models to use
+    :param ld_model: string, '3D' or '1D', defines which limb darkening models to use
     :param grating: string, which instrument grating to use, e.g. 'G141'
     :param grid_selection: string, which systematic grid to use: grid_selection: either one from 'fix_time', 'fit_time', 'fit_inclin', 'fit_msmpr' or 'fit_ecc'
     :param output_dir: string of folder path to save the data to, e.g. '/Users/MyUser/data/'

--- a/exoticism/marginalisation.py
+++ b/exoticism/marginalisation.py
@@ -97,8 +97,8 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plott
     logg = CONFIG_INI.getfloat(exoplanet, 'logg')   # log(g), stellar gravity - depends on whether 1D or 3D limb darkening models are used
 
     # Define limb darkening directory, which is inside this package
-    limbDir = os.path.join(CONFIG_INI.get('data_paths', 'local_path'), 'Limb-darkening')
-    ld_model = CONFIG_INI.get('setup', 'ld_model')
+    limb_dir_parent = marg.find_data_parent('Limb-darkening')
+    limbDir = os.path.join(limb_dir_parent, 'Limb-darkening')
     grat = CONFIG_INI.get('setup', 'grating')
     _uLD, c1, c2, c3, c4, _cp1, _cp2, _cp3, _cp4, _aLD, _bLD = limb_dark_fit(grat, wavelength, M_H, Teff, logg, limbDir,
                                                                       ld_model)

--- a/exoticism/marginalisation.py
+++ b/exoticism/marginalisation.py
@@ -34,7 +34,7 @@ from exoticism.limb_darkening import limb_dark_fit
 import exoticism.margmodule as marg
 
 
-def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plotting=True):
+def total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_selection, output_dir, run_name, plotting=True, report=True):
     """
     Produce marginalised transit parameters from HST lightcurves over a specified wavelength range.
 
@@ -50,9 +50,13 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plott
     :param err: array of error values corresponding to the flux values in y
     :param sh: array corresponding to the shift in wavelength position on the detector throughout the visit. (same length as x, y and err); can be None
     :param wavelength: array of wavelengths covered to compute y
+    :param ld_model: string, '3D' or '2D', defines which limb darkening models to use
+    :param grating: string, which instrument grating to use, e.g. 'G141'
+    :param grid_selection: string, which systematic grid to use: grid_selection: either one from 'fix_time', 'fit_time', 'fit_inclin', 'fit_msmpr' or 'fit_ecc'
     :param output_dir: string of folder path to save the data to, e.g. '/Users/MyUser/data/'
     :param run_name: arbitrary string of the individual run name, e.g. 'whitelight', or 'bin1', or '115-120micron'
     :param plotting: bool, default=True; whether or not interactive plots should be shown
+    :param report: bool, default=True, whether or not to create a PDF report
     :return:
     """
 
@@ -99,14 +103,12 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plott
     # Define limb darkening directory, which is inside this package
     limb_dir_parent = marg.find_data_parent('Limb-darkening')
     limbDir = os.path.join(limb_dir_parent, 'Limb-darkening')
-    grat = CONFIG_INI.get('setup', 'grating')
-    _uLD, c1, c2, c3, c4, _cp1, _cp2, _cp3, _cp4, _aLD, _bLD = limb_dark_fit(grat, wavelength, M_H, Teff, logg, limbDir,
-                                                                      ld_model)
+    _uLD, c1, c2, c3, c4, _cp1, _cp2, _cp3, _cp4, _aLD, _bLD = limb_dark_fit(grating, wavelength, M_H, Teff, logg, limbDir,
+                                                                             ld_model)
 
     # SELECT THE SYSTEMATIC GRID OF MODELS TO USE
     # 1 in the grid means the parameter is fixed, 0 means it is free
     # grid_selection: either one from 'fix_time', 'fit_time', 'fit_inclin', 'fit_msmpr' or 'fit_ecc'
-    grid_selection = CONFIG_INI.get('setup', 'grid_selection')
     grid = marg.wfc3_systematic_model_grid_selection(grid_selection)
     nsys, nparams = grid.shape   # nsys = number of systematic models, nparams = number of parameters
 
@@ -640,7 +642,6 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plott
              allow_pickle=True)
 
     ### Save as PDF report
-    report = CONFIG_INI.get('setup', 'report')
     if report:
 
         # Figure out best five models through the highest weights, and their SDNR
@@ -653,7 +654,7 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plott
 
         # Prepare variables that go into PDF report
         template_vars = {'data_file': CONFIG_INI.get(exoplanet, 'lightcurve_file'),
-                         'run_name': CONFIG_INI.get('data_paths', 'run_name'),
+                         'run_name': run_name,
                          'nsys': nsys,
                          'rl_in': CONFIG_INI.getfloat(exoplanet, 'rl'),
                          'epoch_in': CONFIG_INI.getfloat(exoplanet, 'epoch'),
@@ -693,7 +694,7 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plott
                          'lightcurve_figure': fig2_fname}
 
         # Create PDf report
-        marg.create_pdf_report(template_vars, os.path.join(outDir, 'report_'+exoplanet+'_'+grat+'_'+run_name+'.pdf'))
+        marg.create_pdf_report(template_vars, os.path.join(outDir, 'report_'+exoplanet+'_'+grating+'_'+run_name+'.pdf'))
 
 
 if __name__ == '__main__':
@@ -716,12 +717,16 @@ if __name__ == '__main__':
     x, y, err, sh = np.loadtxt(os.path.join(dataDir, get_timeseries), skiprows=7, unpack=True)
     wavelength = np.loadtxt(os.path.join(dataDir, get_wvln), skiprows=3)
 
-    # What to call the run and whether to turn plotting on
+    # What to call the run and whether to turn plotting on, and some setup parameters
     run_name = CONFIG_INI.get('data_paths', 'run_name')
     plotting = CONFIG_INI.getboolean('setup', 'plotting')
+    report = CONFIG_INI.get('setup', 'report')
+    ld_model = CONFIG_INI.get('setup', 'ld_model')
+    grating = CONFIG_INI.get('setup', 'grating')
+    grid_selection = CONFIG_INI.get('setup', 'grid_selection')
 
     # Run the main function
-    total_marg(exoplanet, x, y, err, sh, wavelength, output_dir, run_name, plotting)
+    total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_selection, output_dir, run_name, plotting, report)
 
     end_time = time.time()
     print('\nTime it took to run the code:', (end_time-start_time)/60, 'min')

--- a/exoticism/marginalisation.py
+++ b/exoticism/marginalisation.py
@@ -74,10 +74,11 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_sel
 
     # Copy the config.ini to the experiment folder.
     print('Saving the configfile to outputs folder.')
+    config_parent = marg.find_data_parent('exoticism')
     try:
-        copy('config_local.ini', outDir)
+        copy(os.path.join(config_parent, 'exoticism', 'config_local.ini'), outDir)
     except IOError:
-        copy('config.ini', outDir)
+        copy(os.path.join(config_parent, 'exoticism', 'config.ini'), outDir)
 
     # READ THE CONSTANTS
     HST_period = CONFIG_INI.getfloat('constants', 'HST_period') * u.d

--- a/exoticism/marginalisation.py
+++ b/exoticism/marginalisation.py
@@ -15,6 +15,7 @@ Initial translation of Python to IDL was done by Matthew Hill (@mattjhill).
 Continued translation and implementation of Sherpa by Iva Laginja (@ivalaginja).
 """
 
+import csv
 import os
 import time
 from shutil import copy
@@ -652,7 +653,7 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_sel
         for i in range(len(best_five_index)):
             sdnr_top_five[i] = marg.calc_sdnr(masked_residuals[best_five_index[i]])
 
-        # Prepare variables that go into PDF report
+        # Prepare variables that go into PDF report as dictionary
         template_vars = {'data_file': CONFIG_INI.get(exoplanet, 'lightcurve_file'),
                          'run_name': run_name,
                          'nsys': nsys,
@@ -694,7 +695,13 @@ def total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_sel
                          'lightcurve_figure': fig2_fname}
 
         # Create PDf report
-        marg.create_pdf_report(template_vars, os.path.join(outDir, 'report_'+exoplanet+'_'+grating+'_'+run_name+'.pdf'))
+        report_fname = f'report_{exoplanet}_{grating}_{run_name}'
+        marg.create_pdf_report(template_vars, os.path.join(outDir, f'{report_fname}.pdf'))
+
+        # Save the same data in a machine readable output format, csv
+        csv_report = csv.writer(open(os.path.join(outDir, 'report.csv'), 'w'))
+        for key, val in template_vars.items():
+            csv_report.writerow([key, val])
 
 
 if __name__ == '__main__':

--- a/exoticism/margmodule.py
+++ b/exoticism/margmodule.py
@@ -469,7 +469,8 @@ def create_pdf_report(template_vars, outfile):
 
     # Create Jinja environment and get template
     from jinja2 import Environment, FileSystemLoader
-    env = Environment(loader=FileSystemLoader(CONFIG_INI.get('data_paths', 'local_path')))
+    template_dir = find_data_parent('exoticism')
+    env = Environment(loader=FileSystemLoader(template_dir))
     template = env.get_template('report_template.html')
 
     # Render HTML with input variables

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -43,7 +43,7 @@ def test_marginalisation_w17_fit_time():
 
     ### Test against old values obtained with ExoTiC-ISM v2.0.0 (tagged)
 
-    # Marginalized parameters
+    # Marginalised parameters
     assert np.isclose(float(output_dict['rl_marg']), 0.12401905841361494, rtol=1e-9), 'rl_marg value is off'
     assert np.isclose(float(output_dict['rl_marg_err']), 0.00019560291752800156, rtol=1e-9), 'rl_marg_err value is off'
     assert np.isclose(float(output_dict['epoch_marg']), 57957.97007898447, rtol=1e-6), 'epoch_marg value is off'

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -52,23 +52,23 @@ def test_marginalisation_w17_fit_time():
     # Number of rejected systematic models
     assert int(output_dict['num_rejected']) == 0, 'No systematic model should have been rejected'
 
-    # Top five model stats - the lists get saved out weirdly to the csv, so reading them back in is a little cumbersome
-    this = output_dict['top_five_numbers'][1:-2]
-    that = this.split(' ')
-    top_five_numbers = [int(i) for i in that]
-    assert top_five_numbers == [0, 1, 2], 'top_five_numbers are incorrect'
+    # Top five model stats - the lists get saved out without commas to the csv, so reading them back in is a little cumbersome
+    this = output_dict['top_five_numbers'][1:-1]        # read stringified list without commas and reject brackets
+    that = this.split(' ')                              # split by white space
+    that_clean = list(filter(None, that))               # reject entries that are empty (in case there where double white spaces)
+    top_five_numbers = [int(i) for i in that_clean]     # cast into list of ints
     assert top_five_numbers == [40, 30, 41, 45, 33], 'top_five_numbers are incorrect'
 
-    this = output_dict['top_five_weights'][1:-2]
+    this = output_dict['top_five_weights'][1:-1]
     that = this.split(' ')
-    top_five_weights = [int(i) for i in that]
-    assert top_five_weights == [0, 1, 2], 'top_five_weights are incorrect'
+    that_clean = list(filter(None, that))
+    top_five_weights = [float(i) for i in that_clean]
     assert np.allclose(top_five_weights, [0.10877472617236775, 0.08219481507255598, 0.08213473840712483, 0.08096430014677133, 0.06651390301754695], rtol=1e-9), 'top_five_weights are incorrect'
 
-    this = output_dict['top_five_sdnr'][1:-2]
+    this = output_dict['top_five_sdnr'][1:-1]
     that = this.split(' ')
-    top_five_sdnr = [int(i) for i in that]
-    assert top_five_sdnr == [0, 1, 2], 'top_five_sdnr are incorrect'
+    that_clean = list(filter(None, that))
+    top_five_sdnr = [float(i) for i in that_clean]
     assert np.allclose(top_five_sdnr, [122.82905364, 125.7510669, 122.29547469, 122.34196309, 122.81473885], rtol=1e-6), 'top_five_sdnr are incorrect'
 
     # Noise stats

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -1,0 +1,72 @@
+import csv
+import glob
+import os
+import numpy as np
+
+from exoticism.config import CONFIG_INI
+from exoticism.margmodule import find_data_parent
+from exoticism.marginalisation import total_marg
+
+
+def test_marginalisation_w17_fit_time():
+    """Test the correct marginalise parameters for W17 with the grid selection 'fit time'."""
+
+    # Set the star/exoplanet system to W17
+    exoplanet = 'W17'
+
+    # Set up data paths that work with CI
+    output_dir = ''
+    data_dir = find_data_parent('data')
+
+    # Read in lightcurve data
+    get_timeseries = CONFIG_INI.get(exoplanet, 'lightcurve_file')
+    get_wvln = CONFIG_INI.get(exoplanet, 'wvln_file')
+    x, y, err, sh = np.loadtxt(os.path.join(data_dir, 'data', exoplanet, get_timeseries), skiprows=7, unpack=True)
+    wavelength = np.loadtxt(os.path.join(data_dir, 'data', exoplanet, get_wvln), skiprows=3)
+
+    # Give it a run name and turn off plotting
+    run_name = 'ci_test_run'
+    plotting = False
+    report = True
+    ld_model = '3D'
+    grating = 'G141'
+    grid_selection = 'fit_time'
+
+    # Run the marginalisation
+    total_marg(exoplanet, x, y, err, sh, wavelength, ld_model, grating, grid_selection, output_dir, run_name, plotting, report)
+
+    # Read the output CSV file
+    run_dir = glob.glob(f'*{run_name}')[0]
+    reader = csv.reader(open(os.path.join(run_dir, 'report.csv'), 'r'))
+    output_dict = dict(reader)
+
+    # Test against old values obtained with commit ???
+    assert np.isclose(float(output_dict['rl_marg']), 3, rtol=0.00001), 'rl_marg value is off'
+    assert np.isclose(float(output_dict['rl_marg_err']), 3, rtol=0.00001), 'rl_marg_err value is off'
+    assert np.isclose(float(output_dict['epoch_marg']), 3, rtol=0.00001), 'epoch_marg value is off'
+    assert np.isclose(float(output_dict['epoch_marg_err']), 3, rtol=0.00001), 'epoch_marg_err value is off'
+
+    assert int(output_dict['num_rejected']) == 0, 'No systematic model should have been rejected'
+
+    this = output_dict['top_five_numbers'][1:-2]
+    that = this.split(' ')
+    top_five_numbers = [int(i) for i in that]
+    assert top_five_numbers == [0, 1, 2], 'top_five_numbers are incorrect'
+
+    this = output_dict['top_five_weights'][1:-2]
+    that = this.split(' ')
+    top_five_weights = [int(i) for i in that]
+    assert top_five_weights == [0, 1, 2], 'top_five_weights are incorrect'
+
+    this = output_dict['top_five_sdnr'][1:-2]
+    that = this.split(' ')
+    top_five_sdnr = [int(i) for i in that]
+    assert top_five_sdnr == [0, 1, 2], 'top_five_sdnr are incorrect'
+
+    assert np.isclose(float(output_dict['white_noise']), 3, rtol=0.00001), 'white_noise value is off'
+    assert np.isclose(float(output_dict['red_noise']), 3, rtol=0.00001), 'red_noise value is off'
+    assert np.isclose(float(output_dict['beta']), 3, rtol=0.00001), 'beta value is off'
+
+
+if __name__ == '__main__':
+    test_marginalisation_w17_fit_time()

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -41,13 +41,13 @@ def test_marginalisation_w17_fit_time():
     reader = csv.reader(open(os.path.join(run_dir, 'report.csv'), 'r'))
     output_dict = dict(reader)
 
-    ### Test against old values obtained with commit ???
+    ### Test against old values obtained with ExoTiC-ISM v2.0.0 (tagged)
 
     # Marginalized parameters
-    assert np.isclose(float(output_dict['rl_marg']), 3, rtol=0.00001), 'rl_marg value is off'
-    assert np.isclose(float(output_dict['rl_marg_err']), 3, rtol=0.00001), 'rl_marg_err value is off'
-    assert np.isclose(float(output_dict['epoch_marg']), 3, rtol=0.00001), 'epoch_marg value is off'
-    assert np.isclose(float(output_dict['epoch_marg_err']), 3, rtol=0.00001), 'epoch_marg_err value is off'
+    assert np.isclose(float(output_dict['rl_marg']), 0.12401905841361494, rtol=1e-9), 'rl_marg value is off'
+    assert np.isclose(float(output_dict['rl_marg_err']), 0.00019560291752800156, rtol=1e-9), 'rl_marg_err value is off'
+    assert np.isclose(float(output_dict['epoch_marg']), 57957.97007898447, rtol=1e-6), 'epoch_marg value is off'
+    assert np.isclose(float(output_dict['epoch_marg_err']), 0.0001836464061859145, rtol=1e-9), 'epoch_marg_err value is off'
 
     # Number of rejected systematic models
     assert int(output_dict['num_rejected']) == 0, 'No systematic model should have been rejected'
@@ -57,21 +57,24 @@ def test_marginalisation_w17_fit_time():
     that = this.split(' ')
     top_five_numbers = [int(i) for i in that]
     assert top_five_numbers == [0, 1, 2], 'top_five_numbers are incorrect'
+    assert top_five_numbers == [40, 30, 41, 45, 33], 'top_five_numbers are incorrect'
 
     this = output_dict['top_five_weights'][1:-2]
     that = this.split(' ')
     top_five_weights = [int(i) for i in that]
     assert top_five_weights == [0, 1, 2], 'top_five_weights are incorrect'
+    assert np.allclose(top_five_weights, [0.10877472617236775, 0.08219481507255598, 0.08213473840712483, 0.08096430014677133, 0.06651390301754695], rtol=1e-9), 'top_five_weights are incorrect'
 
     this = output_dict['top_five_sdnr'][1:-2]
     that = this.split(' ')
     top_five_sdnr = [int(i) for i in that]
     assert top_five_sdnr == [0, 1, 2], 'top_five_sdnr are incorrect'
+    assert np.allclose(top_five_sdnr, [122.82905364, 125.7510669, 122.29547469, 122.34196309, 122.81473885], rtol=1e-6), 'top_five_sdnr are incorrect'
 
     # Noise stats
-    assert np.isclose(float(output_dict['white_noise']), 3, rtol=0.00001), 'white_noise value is off'
-    assert np.isclose(float(output_dict['red_noise']), 3, rtol=0.00001), 'red_noise value is off'
-    assert np.isclose(float(output_dict['beta']), 3, rtol=0.00001), 'beta value is off'
+    assert np.isclose(float(output_dict['white_noise']), 0.00017134399252019425, rtol=1e-9), 'white_noise value is off'
+    assert np.isclose(float(output_dict['red_noise']), 2.9945171057075465e-5, rtol=1e-9), 'red_noise value is off'
+    assert np.isclose(float(output_dict['beta']), 1.1389386251150133, rtol=1e-9), 'beta value is off'
 
 
 if __name__ == '__main__':

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -9,7 +9,7 @@ from exoticism.marginalisation import total_marg
 
 
 def test_marginalisation_w17_fit_time():
-    """Test the correct marginalise parameters for W17 with the grid selection 'fit time'."""
+    """Test the correct marginalised parameters for W17 with the grid selection 'fit time'."""
 
     # Set the star/exoplanet system to W17
     exoplanet = 'W17'

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -75,7 +75,3 @@ def test_marginalisation_w17_fit_time():
     assert np.isclose(float(output_dict['white_noise']), 0.00017134399252019425, rtol=1e-9), 'white_noise value is off'
     assert np.isclose(float(output_dict['red_noise']), 2.9945171057075465e-5, rtol=1e-9), 'red_noise value is off'
     assert np.isclose(float(output_dict['beta']), 1.1389386251150133, rtol=1e-9), 'beta value is off'
-
-
-if __name__ == '__main__':
-    test_marginalisation_w17_fit_time()

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -74,7 +74,7 @@ def test_marginalisation_w17_fit_time():
     that = this.split(' ')
     that_clean = list(filter(None, that))
     top_five_sdnr = [float(i) for i in that_clean]
-    assert np.allclose(top_five_sdnr, [122.82905364, 125.7510669, 122.29547469, 122.34196309, 122.81473885], rtol=1e-6), 'top_five_sdnr are incorrect'
+    assert np.allclose(top_five_sdnr, [122.82905364, 125.7510669, 122.29547469, 122.34196309, 122.81473885], rtol=1e-3), 'top_five_sdnr are incorrect'
 
     # Noise stats
     assert np.isclose(float(output_dict['white_noise']), 0.00017134399252019425, rtol=1e-9), 'white_noise value is off'

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -40,14 +40,18 @@ def test_marginalisation_w17_fit_time():
     reader = csv.reader(open(os.path.join(run_dir, 'report.csv'), 'r'))
     output_dict = dict(reader)
 
-    # Test against old values obtained with commit ???
+    ### Test against old values obtained with commit ???
+
+    # Marginalized parameters
     assert np.isclose(float(output_dict['rl_marg']), 3, rtol=0.00001), 'rl_marg value is off'
     assert np.isclose(float(output_dict['rl_marg_err']), 3, rtol=0.00001), 'rl_marg_err value is off'
     assert np.isclose(float(output_dict['epoch_marg']), 3, rtol=0.00001), 'epoch_marg value is off'
     assert np.isclose(float(output_dict['epoch_marg_err']), 3, rtol=0.00001), 'epoch_marg_err value is off'
 
+    # Number of rejected systematic models
     assert int(output_dict['num_rejected']) == 0, 'No systematic model should have been rejected'
 
+    # Top five model stats - the lists get saved out weirdly to the csv, so reading them back in is a little cumbersome
     this = output_dict['top_five_numbers'][1:-2]
     that = this.split(' ')
     top_five_numbers = [int(i) for i in that]
@@ -63,6 +67,7 @@ def test_marginalisation_w17_fit_time():
     top_five_sdnr = [int(i) for i in that]
     assert top_five_sdnr == [0, 1, 2], 'top_five_sdnr are incorrect'
 
+    # Noise stats
     assert np.isclose(float(output_dict['white_noise']), 3, rtol=0.00001), 'white_noise value is off'
     assert np.isclose(float(output_dict['red_noise']), 3, rtol=0.00001), 'red_noise value is off'
     assert np.isclose(float(output_dict['beta']), 3, rtol=0.00001), 'beta value is off'

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -44,10 +44,15 @@ def test_marginalisation_w17_fit_time():
     ### Test against old values obtained with ExoTiC-ISM v2.0.0 (tagged)
 
     # Marginalised parameters
-    assert np.isclose(float(output_dict['rl_marg']), 0.12401905841361494, rtol=1e-9), 'rl_marg value is off'
-    assert np.isclose(float(output_dict['rl_marg_err']), 0.00019560291752800156, rtol=1e-9), 'rl_marg_err value is off'
-    assert np.isclose(float(output_dict['epoch_marg']), 57957.97007898447, rtol=1e-6), 'epoch_marg value is off'
-    assert np.isclose(float(output_dict['epoch_marg_err']), 0.0001836464061859145, rtol=1e-9), 'epoch_marg_err value is off'
+    set_rl_marg = 0.12401905841361494
+    set_rl_marg_err = 0.00019560291752800156
+    set_epoch_marg = 57957.97007898447
+    set_epoch_marg_err = 0.0001836464061859145
+
+    assert np.isclose(float(output_dict['rl_marg']), set_rl_marg, rtol=set_rl_marg_err), 'rl_marg value is off'
+    assert np.isclose(float(output_dict['rl_marg_err']), set_rl_marg_err, rtol=1e-9), 'rl_marg_err value is off'
+    assert np.isclose(float(output_dict['epoch_marg']), set_epoch_marg, rtol=set_epoch_marg_err), 'epoch_marg value is off'
+    assert np.isclose(float(output_dict['epoch_marg_err']), set_epoch_marg_err, rtol=1e-9), 'epoch_marg_err value is off'
 
     # Number of rejected systematic models
     assert int(output_dict['num_rejected']) == 0, 'No systematic model should have been rejected'

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -68,7 +68,7 @@ def test_marginalisation_w17_fit_time():
     that = this.split(' ')
     that_clean = list(filter(None, that))
     top_five_weights = [float(i) for i in that_clean]
-    assert np.allclose(top_five_weights, [0.10877472617236775, 0.08219481507255598, 0.08213473840712483, 0.08096430014677133, 0.06651390301754695], rtol=1e-4), 'top_five_weights are incorrect'
+    assert np.allclose(top_five_weights, [0.10877472617236775, 0.08219481507255598, 0.08213473840712483, 0.08096430014677133, 0.06651390301754695], rtol=1e-3), 'top_five_weights are incorrect'
 
     this = output_dict['top_five_sdnr'][1:-1]
     that = this.split(' ')

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -15,6 +15,7 @@ def test_marginalisation_w17_fit_time():
     exoplanet = 'W17'
 
     # Set up data paths that work with CI
+    # Outputs will be dumped in the same directory like this test lives in and can/should be deleted when done.
     output_dir = ''
     data_dir = find_data_parent('data')
 

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -79,4 +79,4 @@ def test_marginalisation_w17_fit_time():
     # Noise stats
     assert np.isclose(float(output_dict['white_noise']), 0.00017134399252019425, rtol=1e-9), 'white_noise value is off'
     assert np.isclose(float(output_dict['red_noise']), 2.9945171057075465e-5, rtol=1e-9), 'red_noise value is off'
-    assert np.isclose(float(output_dict['beta']), 1.1389386251150133, rtol=1e-9), 'beta value is off'
+    assert np.isclose(float(output_dict['beta']), 1.1389386251150133, rtol=1e-4), 'beta value is off'

--- a/exoticism/tests/test_marginalisation.py
+++ b/exoticism/tests/test_marginalisation.py
@@ -68,7 +68,7 @@ def test_marginalisation_w17_fit_time():
     that = this.split(' ')
     that_clean = list(filter(None, that))
     top_five_weights = [float(i) for i in that_clean]
-    assert np.allclose(top_five_weights, [0.10877472617236775, 0.08219481507255598, 0.08213473840712483, 0.08096430014677133, 0.06651390301754695], rtol=1e-9), 'top_five_weights are incorrect'
+    assert np.allclose(top_five_weights, [0.10877472617236775, 0.08219481507255598, 0.08213473840712483, 0.08096430014677133, 0.06651390301754695], rtol=1e-4), 'top_five_weights are incorrect'
 
     this = output_dict['top_five_sdnr'][1:-1]
     that = this.split(' ')


### PR DESCRIPTION
Working on issue #96.

This PR adds a regression test. It compares the outputs of a fresh run of the main marginalisation function to outputs obtained with `ExoTiC-ISM` v2.0.0, which have been checked for correctness.

Also:
- adds the output of a `report.csv` so that the results also get saved out in machine readable form, on top of the PDF report
- links to the limb darkening folder with an absolute path by querying, rather than reading it from the configfile
- copies the configfile by querying for its path rather than reading it from the configfile
- pulls out more of the parameters in the marginalisation to be function input parameters